### PR TITLE
Feature #10: Add jinja2 template processing and support for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ It has the following properties:
 
 > **Note**: Arguments marked with `*` are obligatory!
 
+> **Warning**: Remember to install the version of `pytorch-cuda` package compliant to your CUDA Toolkit version.
+
 
 ##### ✍️ Example
 ```toml
@@ -169,7 +171,7 @@ You can define following properties:
 type = "csv"
 # for CSVLogger, we need to define 'save_dir' argument and/or
 # other extra ones (https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.loggers.csv_logs.html#module-lightning.pytorch.loggers.csv_logs)
-save_dir = "${PROJECT_DIR}/my_metrics.csv"
+save_dir = "{{ PROJECT_DIR }}/my_metrics.csv"
 
 # then we define level and format for logging messages
 level = "info"
@@ -460,14 +462,14 @@ In the section, you can define the following proeprties:
 ##### ✍️ Example
 ```toml
 [training.checkpoint]
-path = "${PROJECT_DIR}/chckpt"
+path = "{{ PROJECT_DIR }}/chckpt"
 monitor = {"metric" = "Precision", "stage" = "val"}
 filename = "{epoch}_{val_precision:.2f}_cnn"
 mode = "max"
 save_top_k = 1
 ```
 
-> **Note**: You can see we used substitutable symbol `${PROJECT_DIR}`. More about them in the Section [Substitutable symbols](#substitutable-symbols).
+> **Note**: You can see we used substitutable symbol `{{ PROJECT_DIR }}`. More about them in the Section [Substitutable symbols](#substitutable-symbols).
 
 
 
@@ -492,13 +494,33 @@ It might be set in several different ways:
 
 #### Substitutable symbols
 In the configuration file you can use symbols that will be substituted during the runtime.
-The symbols should be used in curly brackets (e.g. `${PROJECT_DIR}`.)
+The symbols should be surrended by single spaces and in double curly brackets (e.g. `{{ PROJECT_DIR }}`.)
 
 |   **Symbol** 	|            **Meaning of the symbol**                                   	|          **Example**                  |
 |-------------	|-----------------------------------------------------------------------	| -----------------------------------	|
-| `PROJECT_DIR`	| the home directory of the TOML configuration file (project directory) 	| `target = ${PROJECT_DIR}/model.py`     |
+| `PROJECT_DIR`	| the home directory of the TOML configuration file (project directory) 	| `target = {{ PROJECT_DIR }}/model.py`     |
 
+> **Note**: You can also use environmental variables. Just use `env` dict, e.g.: `{{ env['your_var_name'] }}`.
 
+##### ✍️ Example
+First, let's define some environmental variable: using Python or system tool.
+```python
+import os
+
+os.environ["MY_LOG_LEVEL"] = "INFO"
+```
+or
+```bash
+export MY_LOG_LEVEL="MY_LOG_LEVEL"
+```
+Now, we can use the environmental variable `MY_LOG_LEVEL` in our config file:
+
+```toml
+[logging]
+level = "{{ env['MY_LOG_LEVEL'] }}"
+format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+```
+> **Warning**: If you use **double quote** for text values in TOML configuration file, then use **single quote** to access `env` values. 
 
 #### Context constants
 When you run training using `mlkit train` command, all custom modules have access to context constant values (defined for the current Python interpreter session).

--- a/dev-env.yaml
+++ b/dev-env.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.10
   - pytorch
-  - pytorch-cuda=11.8
+  - pytorch-cuda
   - torchvision 
   - torchmetrics
   - lightning
@@ -20,6 +20,7 @@ dependencies:
   - isort
   - pydocstyle
   - pytest
+  - jinja2
   - conda-build
   - pip
   - pip:

--- a/env.yaml
+++ b/env.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.10
   - pytorch
-  - pytorch-cuda=11.8
+  - pytorch-cuda
   - torchvision 
   - torchmetrics
   - lightning
@@ -15,6 +15,7 @@ dependencies:
   - pydantic
   - tqdm
   - toml
+  - jinja2
   - pip
   - pip:
     - typer[all]

--- a/examples/cnn_s3dis_segmentation/conf.toml
+++ b/examples/cnn_s3dis_segmentation/conf.toml
@@ -19,7 +19,7 @@ epoch_schedulers = [
 accumulate_grad_batches = 5
 
 [training.checkpoint]
-path = "${PROJECT_DIR}/chckpt"
+path = "{{ PROJECT_DIR }}/chckpt"
 monitor = {"metric" = "JaccardIndexMacro", "stage" = "val"}
 filename = "{epoch}_{val_jaccardindexmacro:.2f}_cnn"
 mode = "max"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -20,7 +20,7 @@ class TestFormatting:
     def load(self) -> str:
         return """
         [section]
-        target = "${PROJECT_DIR}/data.nc"
+        target = "{{ PROJECT_DIR }}/data.nc"
         """
 
     def test_substitute_symbols(self, load):
@@ -29,19 +29,8 @@ class TestFormatting:
         assert entries["section"]["target"] == "/work/usr/data.nc"
 
     def test_fail_on_missing_placeholder_definition(self, load):
-        with pytest.raises(KeyError, match=r"'PROJECT_DIR'"):
+        with pytest.raises(ValueError, match=r"'PROJECT_DIR' is undefined"):
             _ = substitute_symbols(load)
-
-    def test_not_fail_if_format_symbols_used(self):
-        load: str = """
-        [section]
-        target = "${PROJECT_DIR}/data.nc"
-        extra = "{some_attribute}"
-        """
-        result = substitute_symbols(load, PROJECT_DIR="/work/usr")
-        entries = toml.loads(result)
-        assert entries["section"]["target"] == "/work/usr/data.nc"
-        assert entries["section"]["extra"] == "{some_attribute}"
 
     @patch("os.sep", _UNIX_PATHNAME_SEP)
     def test_substitute_windows_path_to_unix(self):
@@ -72,3 +61,15 @@ class TestFormatting:
         load = "D:\\Program Files/dir1/dir2\\file.txt"
         escaped = escape_os_sep(load)
         assert escaped == "D:/Program Files/dir1/dir2/file.txt"
+
+    def test_use_env_var_in_conf(self):
+        import os
+
+        os.environ["env_path"] = "/usr/new_path"
+        load: str = """
+        [section]
+        target = "{{ env['env_path'] }}/data.nc"
+        """
+        result = substitute_symbols(load)
+        entries = toml.loads(result)
+        assert entries["section"]["target"] == "/usr/new_path/data.nc"


### PR DESCRIPTION
## What does this PR do?

- [x] support for Jinja2 substitutable symbols in TOML file
- [x] make env vars available via `env` dict-like variable (e.g. `env['...']`)
- [x] add unit tests

Closes #10 

## To do before submitting

- [x] Is there an issue the pull request is related to?
- [x] Did you run `make prepublish`?
- [x] Was no error raised by the above command?
- [x] Is the title clear and description relevant?
