### PR TITLE
F #66: Enable overwriting confguration parameters

### DIFF
--- a/kit4dl/__init__.py
+++ b/kit4dl/__init__.py
@@ -120,15 +120,23 @@ def _overwrite_dict(mapping: dict, overwrite: dict | None = None) -> None:
     def _replace_recursively(mapping, key, value):
         key_0, *subkeys = key.split(".", maxsplit=1)
         if subkeys:
-            _replace_recursively(mapping[key_0], ".".join(subkeys), value)
-        else:
-            mapping[key_0] = value
+            return _replace_recursively(
+                mapping[key_0], ".".join(subkeys), value
+            )
+        if key_0 not in mapping:
+            return False
+        mapping[key_0] = value
+        return True
 
     if not overwrite:
         return
     log.info("Overwriting configuration dictionary with %s", overwrite)
     for key, value in overwrite.items():
-        _replace_recursively(mapping, key, value)
+        changed = _replace_recursively(mapping, key, value)
+        if not changed:
+            raise KeyError(
+                f"Key {key} not found in the configuration dictionary."
+            )
 
 
 def update_context_from_static() -> None:

--- a/tests/nn/test_confmodels.py
+++ b/tests/nn/test_confmodels.py
@@ -569,7 +569,6 @@ class TestConf:
         type = "csv"
         name = "logging_exp_name"
         """
-        breakpoint()
         conf = Conf(**toml.loads(load))
         assert "name" in conf.logging.arguments
         assert conf.logging.arguments["name"] == "logging_exp_name"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,8 +10,15 @@ class TestInit:
         return {"a": {"b": {"c": 100}}, "d": 50}
 
     def test_overwrite_root_level_key(self, conf_dict):
-        _overwrite_dict(conf_dict, {"a.d": 100})
-        assert conf_dict["a"]["d"] == 100
+        _overwrite_dict(conf_dict, {"d": 100})
+        assert conf_dict["d"] == 100
+
+        _overwrite_dict(conf_dict, {"a.b": 100})
+        assert conf_dict["a"]["b"] == 100
+
+    def test_raise_if_key_not_found(self, conf_dict):
+        with pytest.raises(KeyError):
+            _overwrite_dict(conf_dict, {"a.e": 100})
 
     def test_overwrite_multiple_level_key(self, conf_dict):
         _overwrite_dict(conf_dict, {"a.b.c": 500})


### PR DESCRIPTION
## What does this PR do?
It is not possible to overwrite configuration parameters using CLI, e.g:

```bash
kit4dl train --overwrite "logging.level=debug,training.optimizer.lr=0.1" 
```
will modify logging level to DEBUG and optimizer learning rate to `0.1`.
Closes #66

## To do before submitting

- [x] Is there an issue the pull request is related to?
- [x] Did you run `make prepublish`?
- [x] Was no error raised by the above command?
- [x] Is the title clear and description relevant?
